### PR TITLE
buildenv: Implement croot to get back to SRC_DIR quickly

### DIFF
--- a/buildenv.sh
+++ b/buildenv.sh
@@ -50,6 +50,20 @@ run_cmd()
         bash -e "$SRC_DIR/scripts/$CMD.sh" "$@"
     fi
 }
+
+croot()
+{
+    if [ -d "$SRC_DIR" ]; then
+	if [ "$1" ]; then
+	    cd "$SRC_DIR/$1"
+	else
+	    cd "$SRC_DIR"
+	fi
+    else
+        echo "Unable to find source directory. Try setting SRC_DIR"
+        return 1
+    fi
+}
 # ]
 
 TARGETS="$(ls "$SRC_DIR/target")"


### PR DESCRIPTION
UN1CA has been growing in the last months and there are lots of modules and subdirectories, this commit wants to help returning quickly to the top directory with a single command.

croot:      Changes directory to the top of the tree, or a subdirectory thereof.

This follows the AOSP implementation of croot in envsetup.sh More details: https://github.com/LineageOS/android_build/blob/lineage-21.0/envsetup.sh#L1083